### PR TITLE
* spaces.el (sp-switch-space): Fix an error when calling sp-switch-space for the first time.

### DIFF
--- a/spaces.el
+++ b/spaces.el
@@ -127,7 +127,7 @@ is the current space, we reload the current space's saved
 config."
   (interactive)
   (if (and (null name) (null sp-spaces))
-      (error "no spaces defined yet")
+      (call-interactively 'sp-new-space)
       (let ((name (or name (ido-completing-read "space: "
                                                 (let ((names (sp-space-names)))
                                                   (append


### PR DESCRIPTION
Call `sp-new-space' instead of error.
